### PR TITLE
Improve codex setup script

### DIFF
--- a/codex-setup.sh
+++ b/codex-setup.sh
@@ -1,23 +1,18 @@
 #!/bin/bash
 set -e
 
-# Ensure local bin directory exists and is in PATH
-STACK_LOCAL_BIN="$HOME/.local/bin"
-mkdir -p "$STACK_LOCAL_BIN"
-export PATH="$STACK_LOCAL_BIN:$PATH"
-
-# Download stack if it's not installed
+# Install stack via apt-get if it's not already available
 if ! command -v stack >/dev/null 2>&1; then
-  echo "Downloading stack..."
-  curl -L https://www.stackage.org/stack/linux-x86_64 \
-    | tar xz --wildcards --strip-components=1 -C "$STACK_LOCAL_BIN" '*/stack'
+  echo "Installing stack..."
+  apt-get update
+  apt-get install -y haskell-stack
 fi
 
-# Update package index and install GHC if necessary
+# Build the project using stack
 stack update
 stack --no-terminal setup
+stack build
 
 cat <<'END'
-Stack is installed and GHC is set up. You can now install the project dependencies with:
-  stack install
+Stack is installed and the project has been built.
 END


### PR DESCRIPTION
## Summary
- update `codex-setup.sh` to install Stack via apt-get
- have the setup script build the project automatically

## Testing
- `bash codex-setup.sh` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe3edea0832b858c8a814b1a4d50